### PR TITLE
libc: Mark libstdc++ as vendor available

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -1868,6 +1868,7 @@ cc_library {
     static_ndk_lib: true,
     system_shared_libs: ["libc"],
     static_libs: ["libasync_safe"],
+    vendor_available: true,
 
     //TODO (dimitry): This is to work around b/24465209. Remove after root cause is fixed
     arch: {


### PR DESCRIPTION
A lot of blobs still link this even on 8.1, so allow
devices to build a vendor copy of it.

Change-Id: I2349478ec0507e3a5136fe89f15e7dc4bfc1a03e